### PR TITLE
fix: remove `(Chinese)` remark of `GL Configuration` in nav menu.

### DIFF
--- a/_jade/en/nav-mixin.jade
+++ b/_jade/en/nav-mixin.jade
@@ -28,7 +28,7 @@ mixin nav(basePath, cdnBasePath)
                         li
                             a(href="#{basePath}/en/option.html") Chart Configuration
                         li
-                            a(href="#{basePath}/en/option-gl.html") GL Configuration (Chinese)
+                            a(href="#{basePath}/en/option-gl.html") GL Configuration
                         li
                             a(href="#{basePath}/en/changelog.html") Changelog
                 li#nav-download.dropdown


### PR DESCRIPTION
Currently, the document of GL Configuration has a English version and I think`(Chinese)` remark is not needed any more.

![image](https://user-images.githubusercontent.com/26999792/84502499-033f6600-aceb-11ea-8c9c-4855559d633b.png)
