### PR TITLE
fix(footer): corrected wrong email link in en footer.

### DIFF
--- a/_jade/en/footer.jade
+++ b/_jade/en/footer.jade
@@ -8,7 +8,7 @@ footer
                 a(href='https://www.apache.org')
                     img(src='#{cdnPayRoot}/#{ecWWWLang}/images/asf_logo.svg?_v_=#{cdnPayVersion}', class="footer-apache-logo")
                 .icon-panel
-                    a.footer-icon(href='mailto:dev@echarts.apache.com?Body=%28Thanks%20for%20using%20ECharts.%20Email%20us%20if%20you%20have%20non-technical%20problems%20using%20ECharts.%20For%20technical%20support%2C%20please%20go%20to%20https%3A//github.com/apache/incubator-echarts/issues%20.%29')
+                    a.footer-icon(href='mailto:dev@echarts.apache.org?body=%28Thanks%20for%20using%20ECharts.%20Email%20us%20if%20you%20have%20non-technical%20problems%20using%20ECharts.%20For%20technical%20support%2C%20please%20go%20to%20https%3A//github.com/apache/incubator-echarts/issues%20.%29')
                         img(src='#{cdnPayRoot}/#{ecWWWLang}/images/icon-email.png?_v_=#{cdnPayVersion}')
                     a.footer-icon(href='https://twitter.com/EChartsJs')
                         img(src='#{cdnPayRoot}/#{ecWWWLang}/images/icon-twitter.png?_v_=#{cdnPayVersion}')


### PR DESCRIPTION
Fix the incorrect email link in English footer, dev@echarts.apache.com should be dev@echarts.apache.org.

![image](https://user-images.githubusercontent.com/26999792/87177016-8a452580-c30d-11ea-8c10-72b4549747a0.png)
