### PR TITLE
fix(faq): fix a typo and some style flaws and update some links.

### DIFF
--- a/_jade/en/faq.jade
+++ b/_jade/en/faq.jade
@@ -31,7 +31,7 @@ block content
                 p 1）It is recommended that you read the navigation on the left side of the <a href="https://echarts.apache.org/en/option.html">option manual</a> before you ask questions. In the option manual, you can find out what configuration items does ECharts have. And you can find under the relevant components whether there are configuration items that can implement the functions you need.
                 p 2）Broswe FAQ questions on this page.
                 p 3）Create a simple example to reproduce your problem on  <a href="https://gallery.echartsjs.com/editor.html">ECharts Gallery</a>. If you can't use the code to describe the requirements, you can try to provide a design draft or draw a sketch.
-                p 4）Paste the link when you ask questions on <a href="https://stackoverflow.com">stackoverflow</a>, <a href="https://www.oschina.net/question/tag/echarts">OSCCHINA</a> or <a href="https://segmentfault.com/t/echarts">segmentfault.com</a> and etc. Plaes attach the example link.
+                p 4）Paste the link when you ask questions on <a href="https://stackoverflow.com">stackoverflow</a>, <a href="https://www.oschina.net/question/tag/echarts">OSCHINA</a> or <a href="https://segmentfault.com/t/echarts">segmentfault.com</a> and etc. Plaes attach the example link.
 
 
                 h3 Is ECharts free to use?
@@ -47,7 +47,7 @@ block content
 
                 h3 How do I force the first / last label of the axis to be displayed?
                 p Both <a href="https://echarts.apache.org/en/option.html#xAxis.axisLabel.showMinLabel">axisLabel.showMinLabel</a> and <a href="https://echarts.apache.org/en/option.html#xAxis.axisLabel.showMaxLabel">axisLabel.showMaxLabel</a> are supported since ECharts version 3.5.2. It can be used to control whether the first / last tags are forced to display.
-                p If you can't update the version, please refer to this<a href="https://gallery.echartsjs.com/editor.html?c=xry06afSje"> example </a>to achieve the same effect.
+                p If you can't update the version, please refer to this <a href="https://gallery.echartsjs.com/editor.html?c=xry06afSje">example</a> to achieve the same effect.
 
 
 
@@ -95,7 +95,7 @@ block content
                 h3 How to use ECharts with Baidu map?
                 ol
                     li Include <code>echarts.js</code>, <code>bmap.js</code> and <code>https://api.map.baidu.com/api?v=2.0&ak=Here is the access key you obtained on the Baidu development platform</code>.
-                    li Set <code>bmap</code> in <code>option</code>，You can refer to this<a href="https://gallery.echartsjs.com/editor.html?c=effectScatter-bmap"> example</a>.
+                    li Set <code>bmap</code> in <code>option</code>，You can refer to this <a href="https://echarts.apache.org/examples/en/editor.html?c=effectScatter-bmap">example</a>.
                     li If you need to get a Baidu map instance, you can use <code>chart.getModel().getComponent('bmap').getBMap()</code>，and then make do settings based on <a href="https://lbsyun.baidu.com/cms/jsapi/reference/jsapi_reference.html">Baidu Maps API</a> .
                 p There are more examples about Baidu maps on <a href="https://gallery.echartsjs.com/explore.html#components=bmap~sort=rank~timeframe=all~author=all">ECharts Gallery</a> , which can be used as a reference.
 

--- a/_jade/en/faq.jade
+++ b/_jade/en/faq.jade
@@ -29,7 +29,7 @@ block content
                 h2#ask-questions General Questions
                 h3 What to do if you have technical problem?
                 p 1）It is recommended that you read the navigation on the left side of the <a href="https://echarts.apache.org/en/option.html">option manual</a> before you ask questions. In the option manual, you can find out what configuration items does ECharts have. And you can find under the relevant components whether there are configuration items that can implement the functions you need.
-                p 2）Broswe FAQ questions on this page.
+                p 2）Browse FAQ questions on this page.
                 p 3）Create a simple example to reproduce your problem on  <a href="https://gallery.echartsjs.com/editor.html">ECharts Gallery</a>. If you can't use the code to describe the requirements, you can try to provide a design draft or draw a sketch.
                 p 4）Paste the link when you ask questions on <a href="https://stackoverflow.com">stackoverflow</a>, <a href="https://www.oschina.net/question/tag/echarts">OSCHINA</a> or <a href="https://segmentfault.com/t/echarts">segmentfault.com</a> and etc. Plaes attach the example link.
 

--- a/_jade/zh/faq.jade
+++ b/_jade/zh/faq.jade
@@ -93,8 +93,8 @@ block content
                 h3 如何结合百度地图使用 ECharts？
                 ol
                     li 引入 <code>echarts.js</code>、<code>bmap.js</code> 以及 <code>https://api.map.baidu.com/api?v=2.0&ak=这里填在百度开发平台注册得到的 access key</code>；
-                    li 在 <code>option</code> 中设置 <code>bmap</code>，参考<a href="https://gallery.echartsjs.com/editor.html?c=effectScatter-bmap">这个例子</a>；
-                    li 如需获得百度地图实例，可以通过 <code>chart.getModel().getComponent('bmap').getBMap()</code>，然后根据<a href="https://lbsyun.baidu.com/cms/jsapi/reference/jsapi_reference.html">百度地图 API</a> 做进一步设置。
+                    li 在 <code>option</code> 中设置 <code>bmap</code>，参考<a href="https://echarts.apache.org/examples/zh/editor.html?c=effectScatter-bmap">这个例子</a>；
+                    li 如需获得百度地图实例，可以通过 <code>chart.getModel().getComponent('bmap').getBMap()</code>，然后根据<a href="https://lbsyun.baidu.com/cms/jsapi/reference/jsapi_reference.html">百度地图 API</a>做进一步设置。
                 p <a href="https://gallery.echartsjs.com/explore.html#components=bmap~sort=rank~timeframe=all~author=all">Gallery</a> 上有更多百度地图的例子，可作为参考。
 
 


### PR DESCRIPTION
**(1) fixed typos**
`OSCCHINA` -> `OSCHINA`
`Broswe` -> `Browse`

**(2) fixed some style flaws**
space and indent

**(3) updated the links of the examples of `bmap`**
use the examples on ECharts official website instead of ECharts Gallery, which is just for Chinese.